### PR TITLE
Use full asset name as destination path

### DIFF
--- a/UnityLive2DExtractor/Program.cs
+++ b/UnityLive2DExtractor/Program.cs
@@ -73,9 +73,9 @@ namespace UnityLive2DExtractor
                 if (key == null)
                     continue;
                 var name = key.Substring(key.LastIndexOf("/") + 1);
-                Console.WriteLine($"Extract {name}");
+                Console.WriteLine($"Extract {key}");
 
-                var destPath = Path.Combine(baseDestPath, name) + Path.DirectorySeparatorChar;
+                var destPath = Path.Combine(baseDestPath, key) + Path.DirectorySeparatorChar;
                 var destTexturePath = Path.Combine(destPath, "textures") + Path.DirectorySeparatorChar;
                 var destAnimationPath = Path.Combine(destPath, "motions") + Path.DirectorySeparatorChar;
                 Directory.CreateDirectory(destPath);


### PR DESCRIPTION
Prevent an exception from occuring if the last part of the asset path is shared across bundles

For example :

- bundle_a
   - assets/a/shared/a.model3.json
- bundle_b
   - assets/b/shared/b.model3.json

Previously, UnityLive2DExtractor would create `Live2DOutput/shared/` while processing _bundle_a_, and then try to override it while processing _bundle_b_.
Now, bundles are output to different paths.