### PR TITLE
多个live2d模型只会导出一个

### DIFF
--- a/UnityLive2DExtractor/Program.cs
+++ b/UnityLive2DExtractor/Program.cs
@@ -67,13 +67,7 @@ namespace UnityLive2DExtractor
                     }
                 }
             }
-            var basePathList = new List<string>();
-            foreach (var cubismMoc in cubismMocs)
-            {
-                var container = containers[cubismMoc];
-                var basePath = container.Substring(0, container.LastIndexOf("/"));
-                basePathList.Add(basePath);
-            }
+            var basePathList = cubismMocs.Select(cubismMoc => containers[cubismMoc]).Select(container => container).ToList();
             var lookup = containers.ToLookup(x => basePathList.Find(b => x.Value.Contains(b)), x => x.Key);
             var baseDestPath = Path.Combine(Path.GetDirectoryName(args[0]), "Live2DOutput");
             foreach (var assets in lookup)


### PR DESCRIPTION
用文件夹尝试导出多个live2d时 似乎只会导出一个
看了一下是因为 
var basePath = container.Substring(0, container.LastIndexOf("/"));
因为每个文件container都是resources/live2d/model/live2d模型名 这样的格式

导致不同的l2d相互覆盖了

